### PR TITLE
fix(ci): Add permissions flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - "v*" # Skip tags
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
# Checklist for this pull request

🚨 Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- Make sure you are requesting your **branch** (right side).
- Make sure you are making a pull request against the **main branch** (left side).
- Check the commits message styles matches our [requested structure](https://www.conventionalcommits.org/en/v1.0.0/).
- Check that documentation exists (comments, markdown, etc.).

## Description

Security alerts:

_If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write._

❤️ Thank you!
